### PR TITLE
Updates, enhancements, bugfixes

### DIFF
--- a/src/main/build/debug.c
+++ b/src/main/build/debug.c
@@ -74,4 +74,5 @@ const char * const debugModeNames[DEBUG_COUNT] = {
     "RC_SMOOTHING",
     "RX_SIGNAL_LOSS",
     "RC_SMOOTHING_RATE",
+    "ANTI_GRAVITY",
 };

--- a/src/main/build/debug.h
+++ b/src/main/build/debug.h
@@ -92,6 +92,7 @@ typedef enum {
     DEBUG_RC_SMOOTHING,
     DEBUG_RX_SIGNAL_LOSS,
     DEBUG_RC_SMOOTHING_RATE,
+    DEBUG_ANTI_GRAVITY,
     DEBUG_COUNT
 } debugType_e;
 

--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -848,6 +848,8 @@ bool processRx(timeUs_t currentTimeUs)
     pidSetAcroTrainerState(IS_RC_MODE_ACTIVE(BOXACROTRAINER) && sensors(SENSOR_ACC));
 #endif // USE_ACRO_TRAINER
 
+    pidSetAntiGravityState(IS_RC_MODE_ACTIVE(BOXANTIGRAVITY) || feature(FEATURE_ANTI_GRAVITY));
+    
     return true;
 }
 

--- a/src/main/fc/fc_rc.c
+++ b/src/main/fc/fc_rc.c
@@ -197,10 +197,12 @@ static void checkForThrottleErrorResetState(uint16_t rxRefreshRate)
 
     const int16_t rcCommandSpeed = rcCommand[THROTTLE] - rcCommandThrottlePrevious[index];
 
-    if (ABS(rcCommandSpeed) > throttleVelocityThreshold) {
-        pidSetItermAccelerator(CONVERT_PARAMETER_TO_FLOAT(currentPidProfile->itermAcceleratorGain));
-    } else {
-        pidSetItermAccelerator(1.0f);
+    if (!currentPidProfile->anti_gravity_new) {
+        if (ABS(rcCommandSpeed) > throttleVelocityThreshold) {
+            pidSetItermAccelerator(CONVERT_PARAMETER_TO_FLOAT(currentPidProfile->itermAcceleratorGain));
+        } else {
+            pidSetItermAccelerator(1.0f);
+        }
     }
 }
 
@@ -522,7 +524,7 @@ FAST_CODE void processRcCommand(void)
 {
     uint8_t updatedChannel;
 
-    if (isRXDataNew && isAntiGravityModeActive()) {
+    if (isRXDataNew && pidAntiGravityEnabled()) {
         checkForThrottleErrorResetState(currentRxRefreshRate);
     }
 

--- a/src/main/fc/rc_modes.c
+++ b/src/main/fc/rc_modes.c
@@ -63,10 +63,6 @@ bool isAirmodeActive(void) {
     return (IS_RC_MODE_ACTIVE(BOXAIRMODE) || feature(FEATURE_AIRMODE));
 }
 
-bool isAntiGravityModeActive(void) {
-    return (IS_RC_MODE_ACTIVE(BOXANTIGRAVITY) || feature(FEATURE_ANTI_GRAVITY));
-}
-
 bool isRangeActive(uint8_t auxChannelIndex, const channelRange_t *range) {
     if (!IS_RANGE_USABLE(range)) {
         return false;

--- a/src/main/fc/rc_modes.h
+++ b/src/main/fc/rc_modes.h
@@ -132,7 +132,6 @@ void rcModeUpdate(boxBitmask_t *newState);
 void preventModeChanges(void);
 
 bool isAirmodeActive(void);
-bool isAntiGravityModeActive(void);
 
 bool isRangeActive(uint8_t auxChannelIndex, const channelRange_t *range);
 void updateActivatedModes(void);

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -121,7 +121,6 @@ static FAST_RAM_ZERO_INIT float motorMixRange;
 
 float FAST_RAM_ZERO_INIT motor[MAX_SUPPORTED_MOTORS];
 float motor_disarmed[MAX_SUPPORTED_MOTORS];
-static FAST_RAM_ZERO_INIT float throttleHpf;
 
 mixerMode_e currentMixerMode;
 static motorMixer_t currentMixer[MAX_SUPPORTED_MOTORS];
@@ -330,11 +329,6 @@ uint8_t getMotorCount(void)
 float getMotorMixRange(void)
 {
     return motorMixRange;
-}
-
-float getThrottleHpf(void)
-{
-    return throttleHpf;
 }
 
 bool areMotorsRunning(void)
@@ -809,9 +803,11 @@ FAST_CODE_NOINLINE void mixTable(timeUs_t currentTimeUs, uint8_t vbatPidCompensa
         motorMix[i] = mix;
     }
 
+    pidUpdateAGThrottleFilter(throttle);
+    
 #if defined(USE_THROTTLE_BOOST)
-    if (throttleBoost > 0.0f || antiGravityNew) {
-        throttleHpf = throttle - pt1FilterApply(&throttleLpf, throttle);
+    if (throttleBoost > 0.0f) {
+        const float throttleHpf = throttle - pt1FilterApply(&throttleLpf, throttle);
         throttle = constrainf(throttle + throttleBoost * throttleHpf, 0.0f, 1.0f);
     }
 #endif

--- a/src/main/flight/mixer.h
+++ b/src/main/flight/mixer.h
@@ -119,8 +119,6 @@ float getMotorMixRange(void);
 bool areMotorsRunning(void);
 bool mixerIsOutputSaturated(int axis, float errorRate);
 
-float getThrottleHpf(void);
-
 void mixerLoadMix(int index, motorMixer_t *customMixers);
 void mixerInit(mixerMode_e mixerMode);
 
@@ -136,3 +134,4 @@ void stopPwmAllMotors(void);
 float convertExternalToMotor(uint16_t externalValue);
 uint16_t convertMotorToExternal(float motorValue);
 bool mixerIsTricopter(void);
+

--- a/src/main/flight/pid.h
+++ b/src/main/flight/pid.h
@@ -126,7 +126,6 @@ typedef struct pidProfile_s {
     uint8_t crash_recovery;                 // off, on, on and beeps when it is in crash recovery mode
     uint8_t throttle_boost;                 // how much should throttle be boosted during transient changes 0-100, 100 adds 10x hpf filtered throttle
     uint8_t throttle_boost_cutoff;          // Which cutoff frequency to use for throttle boost. higher cutoffs keep the boost on for shorter. Specified in hz.
-    uint8_t anti_gravity_new;               // Option to use new smooth anti-gravity that requires throttle high pass from throttle boost.
     uint8_t iterm_rotation;                 // rotates iterm to translate world errors to local coordinate system
     uint8_t smart_feedforward;              // takes only the larger of P and the D weight feed forward term if they have the same sign.
     uint8_t iterm_relax_type;               // Specifies type of relax algorithm
@@ -139,6 +138,7 @@ typedef struct pidProfile_s {
     uint8_t abs_control_gain;               // How strongly should the absolute accumulated error be corrected for
     uint8_t abs_control_limit;              // Limit to the correction
     uint8_t abs_control_error_limit;        // Limit to the accumulated error
+    uint8_t anti_gravity_new;               // Option to use new smooth anti-gravity that requires throttle high pass from throttle boost.
 } pidProfile_t;
 
 #ifndef USE_OSD_SLAVE
@@ -171,12 +171,10 @@ extern uint32_t targetPidLooptime;
 
 extern float throttleBoost;
 extern pt1Filter_t throttleLpf;
-extern bool antiGravityNew;
 
 void pidResetITerm(void);
 void pidStabilisationState(pidStabilisationState_e pidControllerState);
 void pidSetItermAccelerator(float newItermAccelerator);
-float pidItermAccelerator(void);
 void pidInitFilters(const pidProfile_t *pidProfile);
 void pidInitConfig(const pidProfile_t *pidProfile);
 void pidInit(const pidProfile_t *pidProfile);
@@ -186,3 +184,7 @@ void pidAcroTrainerInit(void);
 void pidSetAcroTrainerState(bool newState);
 void pidInitSetpointDerivativeLpf(uint16_t filterCutoff, uint8_t debugAxis, uint8_t filterType);
 void pidUpdateSetpointDerivativeLpf(uint16_t filterCutoff);
+void pidUpdateAGThrottleFilter(float throttle);
+bool pidOSDAntiGravityActive(void);
+void pidSetAntiGravityState(bool newState);
+bool pidAntiGravityEnabled(void);

--- a/src/main/io/osd.c
+++ b/src/main/io/osd.c
@@ -594,7 +594,7 @@ static bool osdDrawSingleElement(uint8_t item)
 
     case OSD_ANTI_GRAVITY:
         {
-            if (pidItermAccelerator() > 1.0f) {
+            if (pidOSDAntiGravityActive()) {
                 strcpy(buff, "AG");
             }
 

--- a/src/test/unit/arming_prevention_unittest.cc
+++ b/src/test/unit/arming_prevention_unittest.cc
@@ -792,4 +792,5 @@ extern "C" {
     void rescheduleTask(cfTaskId_e, uint32_t) {}
     bool usbCableIsInserted(void) { return false; }
     bool usbVcpIsConnected(void) { return false; }
+    void pidSetAntiGravityState(bool) {}
 }

--- a/src/test/unit/osd_unittest.cc
+++ b/src/test/unit/osd_unittest.cc
@@ -1032,5 +1032,5 @@ extern "C" {
         return false;
     }
 
-    float pidItermAccelerator(void) { return 1.0; }
+    bool pidOSDAntiGravityActive(void) { return false; }
 }


### PR DESCRIPTION
Changes:

General cleanup, restructuring and efficiency improvements

Disconnect from throttle boost - now AG has it's own throttle lowpass.

Fixed not respecting AG feature or mode - was always on when in new mode

Fixed OSD AG element display when in new mode - there's a field that indicates when AG is active and flashes "AG".  That needed tweaking to work with the new mode.

Restored the DEBUG_ITERM_RELAX debugging.

Added DEBUG_ANTI_GRAVITY debugging. debug[0] is AG gain and debug[1] is throttle HPF.
