### PR TITLE
Add separate filter for vbat comp

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1006,6 +1006,7 @@ const clivalue_t valueTable[] = {
     { "dterm_notch_cutoff",         VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { 0, FILTER_FREQUENCY_MAX }, PG_PID_PROFILE, offsetof(pidProfile_t, dterm_notch_cutoff) },
     { "vbat_pid_gain",              VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_PID_PROFILE, offsetof(pidProfile_t, vbatPidCompensation) },
     { "vbat_sag_compensation",      VAR_UINT8  | PROFILE_VALUE, .config.minmaxUnsigned = { 0, 150 }, PG_PID_PROFILE, offsetof(pidProfile_t, vbat_sag_compensation) },
+    { "vbat_sag_lpf_period",        VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, UINT8_MAX }, PG_BATTERY_CONFIG, offsetof(batteryConfig_t, vbatSagLpfPeriod) },
     { "pid_at_min_throttle",        VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_PID_PROFILE, offsetof(pidProfile_t, pidAtMinThrottle) },
     { "anti_gravity_mode",          VAR_UINT8  | PROFILE_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_ANTI_GRAVITY_MODE }, PG_PID_PROFILE, offsetof(pidProfile_t, antiGravityMode) },
     { "anti_gravity_threshold",     VAR_UINT16 | PROFILE_VALUE, .config.minmaxUnsigned = { 20, 1000 }, PG_PID_PROFILE, offsetof(pidProfile_t, itermThrottleThreshold) },

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -625,7 +625,7 @@ static void calculateThrottleAndCurrentMotorEndpoints(timeUs_t currentTimeUs)
             const float vbatFull = batteryConfig()->vbatmaxcellvoltage - 10;
             const float vbatLow = batteryConfig()->vbatwarningcellvoltage;
             const float vbatRangeToCompensate = vbatFull - vbatLow;
-            const float currentCellVoltage = (float)getBatteryAverageCellVoltage();
+            const float currentCellVoltage = getMOCAverageCellVoltage();
             float batteryGoodness = 0.0f;
             // batteryGoodness = 1 when voltage is above vbatFull, and 0 when voltage is below vbatLow
             if (vbatRangeToCompensate > 0.0f) {

--- a/src/main/sensors/battery.c
+++ b/src/main/sensors/battery.c
@@ -119,6 +119,7 @@ PG_RESET_TEMPLATE(batteryConfig_t, batteryConfig,
     .vbatfullcellvoltage = 410,
 
     .vbatLpfPeriod = 30,
+    .vbatSagLpfPeriod = 2, // default to 'fast' compensation, requires high freq battery updates
     .ibatLpfPeriod = 10,
     .vbatDurationForWarning = 0,
     .vbatDurationForCritical = 0,
@@ -518,6 +519,12 @@ uint8_t getBatteryCellCount(void)
 uint16_t getBatteryAverageCellVoltage(void)
 {
     return voltageMeter.filtered / batteryCellCount;
+}
+
+// return the alternate filtered value for use with motor output compensation
+float getMOCAverageCellVoltage(void)
+{
+    return (float)voltageMeter.compFiltered / (float)batteryCellCount;
 }
 
 bool isAmperageConfigured(void)

--- a/src/main/sensors/battery.h
+++ b/src/main/sensors/battery.h
@@ -62,6 +62,7 @@ typedef struct batteryConfig_s {
 
     uint8_t forceBatteryCellCount;          // Number of cells in battery, used for overwriting auto-detected cell count if someone has issues with it.
     uint8_t vbatLpfPeriod;                  // Period of the cutoff frequency for the Vbat filter (in 0.1 s)
+    uint8_t vbatSagLpfPeriod;               // Period of the cutoff frequency for the Vbat motor output compensation filter (in 0.1 s)
     uint8_t ibatLpfPeriod;                  // Period of the cutoff frequency for the Ibat filter (in 0.1 s)
     uint8_t vbatDurationForWarning;      // Period voltage has to sustain before the battery state is set to BATTERY_WARNING (in 0.1 s)
     uint8_t vbatDurationForCritical;         // Period voltage has to sustain before the battery state is set to BATTERY_CRIT (in 0.1 s)
@@ -105,6 +106,7 @@ uint16_t getLegacyBatteryVoltage(void);
 uint16_t getBatteryVoltageLatest(void);
 uint8_t getBatteryCellCount(void);
 uint16_t getBatteryAverageCellVoltage(void);
+float getMOCAverageCellVoltage(void);
 
 bool isAmperageConfigured(void);
 int32_t getAmperage(void);

--- a/src/main/sensors/voltage.h
+++ b/src/main/sensors/voltage.h
@@ -39,6 +39,7 @@ extern const char * const voltageMeterSourceNames[VOLTAGE_METER_COUNT];
 
 typedef struct voltageMeter_s {
     uint16_t filtered;                      // voltage in 0.01V steps
+    uint16_t compFiltered;                      // voltage in 0.01V steps
     uint16_t unfiltered;                    // voltage in 0.01V steps
     bool lowVoltageCutoff;
 } voltageMeter_t;


### PR DESCRIPTION
First pass at a specific filter for motor output scaling so that we
don't have to interfere with osd of vbat. New cli variable:
vbat_sag_lpf_period
Default value is 2

I think several of the function and variable names could be improved, it's all a bit inconsistent at the moment.
