### PR TITLE
Add a flag to control vbat comp

### DIFF
--- a/src/main/cli/settings.c
+++ b/src/main/cli/settings.c
@@ -1407,6 +1407,7 @@ const clivalue_t valueTable[] = {
     { "pwr_on_arm_grace",           VAR_UINT8  | MASTER_VALUE, .config.minmaxUnsigned = { 0, 30 }, PG_SYSTEM_CONFIG, offsetof(systemConfig_t, powerOnArmingGraceTime) },
     { "scheduler_optimize_rate",    VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON_AUTO }, PG_SYSTEM_CONFIG, offsetof(systemConfig_t, schedulerOptimizeRate) },
     { "enable_stick_arming",        VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_SYSTEM_CONFIG, offsetof(systemConfig_t, enableStickArming) },
+    { "vbat_sag_comp_enabled",       VAR_UINT8  | MASTER_VALUE | MODE_LOOKUP, .config.lookup = { TABLE_OFF_ON }, PG_SYSTEM_CONFIG, offsetof(systemConfig_t, vbatSagCompEnabled) },
 
 // PG_VTX_CONFIG
 #ifdef USE_VTX_COMMON

--- a/src/main/config/config.c
+++ b/src/main/config/config.c
@@ -125,6 +125,7 @@ PG_RESET_TEMPLATE(systemConfig_t, systemConfig,
     .configurationState = CONFIGURATION_STATE_DEFAULTS_BARE,
     .schedulerOptimizeRate = SCHEDULER_OPTIMIZE_RATE_AUTO,
     .enableStickArming = false,
+    .vbatSagCompEnabled = false,
 );
 
 uint8_t getCurrentPidProfileIndex(void)

--- a/src/main/config/config.h
+++ b/src/main/config/config.h
@@ -59,6 +59,7 @@ typedef struct systemConfig_s {
     uint8_t configurationState; // The state of the configuration (defaults / configured)
     uint8_t schedulerOptimizeRate;
     uint8_t enableStickArming; // boolean that determines whether stick arming can be used
+    uint8_t vbatSagCompEnabled; // boolean that determines whether vbat compensation can be used
 } systemConfig_t;
 
 PG_DECLARE(systemConfig_t, systemConfig);

--- a/src/main/fc/tasks.c
+++ b/src/main/fc/tasks.c
@@ -229,6 +229,11 @@ void tasksInit(void)
 
     const bool useBatteryVoltage = batteryConfig()->voltageMeterSource != VOLTAGE_METER_NONE;
     setTaskEnabled(TASK_BATTERY_VOLTAGE, useBatteryVoltage);
+
+    // If vbat motor output compensation is used, switch to fast vbat samplingTime
+    if (systemConfig()->vbatSagCompEnabled)
+        rescheduleTask(TASK_BATTERY_VOLTAGE, TASK_PERIOD_HZ(FAST_VBAT_FREQ));
+
     const bool useBatteryCurrent = batteryConfig()->currentMeterSource != CURRENT_METER_NONE;
     setTaskEnabled(TASK_BATTERY_CURRENT, useBatteryCurrent);
     const bool useBatteryAlerts = batteryConfig()->useVBatAlerts || batteryConfig()->useConsumptionAlerts || featureIsEnabled(FEATURE_OSD);
@@ -378,7 +383,7 @@ cfTask_t cfTasks[TASK_COUNT] = {
     [TASK_MAIN] = DEFINE_TASK("SYSTEM", "UPDATE", NULL, taskMain, TASK_PERIOD_HZ(1000), TASK_PRIORITY_MEDIUM_HIGH),
     [TASK_SERIAL] = DEFINE_TASK("SERIAL", NULL, NULL, taskHandleSerial, TASK_PERIOD_HZ(100), TASK_PRIORITY_LOW), // 100 Hz should be enough to flush up to 115 bytes @ 115200 baud
     [TASK_BATTERY_ALERTS] = DEFINE_TASK("BATTERY_ALERTS", NULL, NULL, taskBatteryAlerts, TASK_PERIOD_HZ(5), TASK_PRIORITY_MEDIUM),
-    [TASK_BATTERY_VOLTAGE] = DEFINE_TASK("BATTERY_VOLTAGE", NULL, NULL, batteryUpdateVoltage, TASK_PERIOD_HZ(200), TASK_PRIORITY_MEDIUM),
+    [TASK_BATTERY_VOLTAGE] = DEFINE_TASK("BATTERY_VOLTAGE", NULL, NULL, batteryUpdateVoltage, TASK_PERIOD_HZ(SLOW_VBAT_FREQ), TASK_PRIORITY_MEDIUM), // Freq may be updated in tasksInit
     [TASK_BATTERY_CURRENT] = DEFINE_TASK("BATTERY_CURRENT", NULL, NULL, batteryUpdateCurrentMeter, TASK_PERIOD_HZ(50), TASK_PRIORITY_MEDIUM),
 
 #ifdef USE_TRANSPONDER

--- a/src/main/fc/tasks.h
+++ b/src/main/fc/tasks.h
@@ -21,3 +21,6 @@
 #pragma once
 
 void tasksInit(void);
+
+#define FAST_VBAT_FREQ 200
+#define SLOW_VBAT_FREQ 50

--- a/src/main/flight/mixer.c
+++ b/src/main/flight/mixer.c
@@ -627,7 +627,7 @@ static void calculateThrottleAndCurrentMotorEndpoints(timeUs_t currentTimeUs)
 #endif
 
         // reduce motorRangeMax when battery is full
-        if (vbatSagCompensationFactor > 0.0f) {
+        if (systemConfig()->vbatSagCompEnabled) {
             const float currentCellVoltage = (float)getBatterySagCellVoltage();
             // batteryGoodness = 1 when voltage is above vbatFull, and 0 when voltage is below vbatLow
             float batteryGoodness = 1.0f - constrainf((vbatFull - currentCellVoltage) / vbatRangeToCompensate, 0.0f, 1.0f);

--- a/src/main/flight/pid.c
+++ b/src/main/flight/pid.c
@@ -224,7 +224,7 @@ void resetPidProfile(pidProfile_t *pidProfile)
         .ff_boost = 15,
         .dyn_lpf_curve_expo = 0,
         .level_race_mode = false,
-        .vbat_sag_compensation = 0,
+        .vbat_sag_compensation = 100,
     );
 #ifndef USE_D_MIN
     pidProfile->pid[PID_ROLL].D = 30;


### PR DESCRIPTION
Flag vbat_sag_comp_enabled allows battery compensation to be enabled or
disabled from the CLI. When disabled the battery voltage task is run at
50Hz and the battery compensation code is not run. When enabled the
voltage task is run at 200Hz and the compensation code runs. Constants
for the fast and slow rates are added to tasks.h. The default value for
vbat_sag_compensation is changed to 100 as we no longer need to use it
to disable the feature.
